### PR TITLE
Refonte du portfolio avec design minimaliste et pages dédiées

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Melchissedeck AFOUDAH</title>
+  <title>À propos - Melchissedeck AFOUDAH</title>
   <link rel="stylesheet" href="public/css/style.css" />
 </head>
 <body>
@@ -16,10 +16,12 @@
     <a href="contact.html">Contact</a>
     <a href="CV-AFOUDAH Melchissedeck-data analyst.pdf" target="_blank">CV</a>
   </nav>
-  <header class="hero">
-    <h1>Melchissedeck AFOUDAH</h1>
-    <p>Étudiant en Data &amp; Intelligence Artificielle</p>
-  </header>
+  <main>
+    <section>
+      <h2>À propos de moi</h2>
+      <p>Étudiant passionné par le monde du <strong>Big Data</strong>, je suis actuellement en Bachelor <strong>Data &amp; Intelligence Artificielle</strong> à Hétic, Paris. À la recherche d'une opportunité de stage professionnel ou d'alternance, je vise à intégrer un poste dans la <strong>data</strong>. Mon objectif est de renforcer mes compétences dans ce domaine en appliquant mes connaissances théoriques dans des projets concrets, tout en m'immergeant dans un environnement professionnel stimulant.</p>
+    </section>
+  </main>
   <footer>
     <div class="social-icons">
       <a href="https://github.com/Melchissedeck" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub"></a>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Melchissedeck AFOUDAH</title>
+  <title>Contact - Melchissedeck AFOUDAH</title>
   <link rel="stylesheet" href="public/css/style.css" />
 </head>
 <body>
@@ -16,10 +16,34 @@
     <a href="contact.html">Contact</a>
     <a href="CV-AFOUDAH Melchissedeck-data analyst.pdf" target="_blank">CV</a>
   </nav>
-  <header class="hero">
-    <h1>Melchissedeck AFOUDAH</h1>
-    <p>Étudiant en Data &amp; Intelligence Artificielle</p>
-  </header>
+  <main>
+    <section>
+      <h2>Contactez-moi</h2>
+      <form action="https://formspree.io/f/xrgnqely" method="POST">
+        <div class="row">
+          <div class="field">
+            <label for="name">Nom</label>
+            <input id="name" type="text" name="name">
+          </div>
+          <div class="field">
+            <label for="email">Adresse e-mail</label>
+            <input id="email" type="email" name="email">
+          </div>
+        </div>
+        <div class="row">
+          <div class="field">
+            <label for="phone">Téléphone</label>
+            <input id="phone" type="tel" name="phone">
+          </div>
+        </div>
+        <div class="field">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" placeholder="Saisissez ici..."></textarea>
+        </div>
+        <button type="submit">Envoyer le message</button>
+      </form>
+    </section>
+  </main>
   <footer>
     <div class="social-icons">
       <a href="https://github.com/Melchissedeck" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub"></a>

--- a/education.html
+++ b/education.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Melchissedeck AFOUDAH</title>
+  <title>Éducation - Melchissedeck AFOUDAH</title>
   <link rel="stylesheet" href="public/css/style.css" />
 </head>
 <body>
@@ -16,10 +16,13 @@
     <a href="contact.html">Contact</a>
     <a href="CV-AFOUDAH Melchissedeck-data analyst.pdf" target="_blank">CV</a>
   </nav>
-  <header class="hero">
-    <h1>Melchissedeck AFOUDAH</h1>
-    <p>Étudiant en Data &amp; Intelligence Artificielle</p>
-  </header>
+  <main>
+    <section>
+      <h2>Éducation</h2>
+      <p>Bac S : Lycée Catholique Père Aupiais Cotonou, Bénin (2020 - 2023)</p>
+      <p>Bachelor en Data &amp; IA, Hetic Paris (2023 - 2026)</p>
+    </section>
+  </main>
   <footer>
     <div class="social-icons">
       <a href="https://github.com/Melchissedeck" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub"></a>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Projets - Melchissedeck AFOUDAH</title>
+  <link rel="stylesheet" href="public/css/style.css" />
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Accueil</a>
+    <a href="about.html">À propos</a>
+    <a href="projects.html">Projets</a>
+    <a href="skills.html">Compétences</a>
+    <a href="education.html">Éducation</a>
+    <a href="contact.html">Contact</a>
+    <a href="CV-AFOUDAH Melchissedeck-data analyst.pdf" target="_blank">CV</a>
+  </nav>
+  <main>
+    <section>
+      <h2>Projets Principaux</h2>
+      <div class="project">
+        <h4>Conception d'un jeu RPG en python</h4>
+        <p>Développement d'un jeu de rôle (RPG) en Python, intégrant une interface graphique avec tkinter en collaboration avec une équipe de développeurs pour la conception et la réalisation du jeu.</p>
+        <p><a href="https://github.com/Melchissedeck/jeu_RPG" target="_blank">Voir le projet</a></p>
+      </div>
+      <div class="project">
+        <h4>Model additif de prédiction de vente</h4>
+        <p>Élaboration un modèle de prédiction des ventes de maillots de bain en collectant et analysant neuf années de données de vente spécifiquement liées à ce segment. Cette analyse a permis de déceler les tendances saisonnières essentielles, offrant ainsi une base solide pour optimiser les prévisions de ventes de maillots de bain.</p>
+        <p><a href="https://github.com/Melchissedeck/Additif-Model" target="_blank">Voir le projet</a></p>
+      </div>
+      <div class="project">
+        <h4>Conception d'un dashboard dynamique</h4>
+        <p>Analyse des données de ventes pour identifier les tendances et les opportunités de croissance, et mis en place un système de reporting automatisé pour faciliter le suivi des performances.</p>
+        <p><a href="public/images/Capture d'écran 2024-03-28 211740.png" target="_blank">Voir le projet</a></p>
+      </div>
+      <div class="project">
+        <h4>Conception d'une application Django pour la gestion des étudiants</h4>
+        <p>Mise en place un système de sauvegarde automatique des données pour garantir la sécurité des informations des étudiants tout en permettant aux utilisateurs de l'appli d'enregistrer et de supprimer des informations facilement.</p>
+        <p><a href="https://github.com/Melchissedeck/Application-Django/tree/master" target="_blank">Voir le projet</a></p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="social-icons">
+      <a href="https://github.com/Melchissedeck" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub"></a>
+      <a href="https://www.linkedin.com/in/melchissedeck-afoudah-9002432a7/" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png" alt="LinkedIn"></a>
+    </div>
+  </footer>
+  <script src="public/js/script.js"></script>
+</body>
+</html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,278 +1,166 @@
-/* Style CSS pour le portfolio */
+/* Minimalist portfolio style inspired by Apple */
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    line-height: 1.6;
-    margin: 0;
-    padding: 0;
-    background-color: #fff;
-    color: #000;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  margin: 0;
+  color: #1d1d1f;
+  background-color: #fff;
 }
 
-header {
-    background-color: #000;
-    color: #fff;
-    padding: 20px;
-    text-align: center;
+nav.main-nav {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1rem;
+  background-color: rgba(255,255,255,0.8);
+  backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid #eaeaea;
+  z-index: 1000;
 }
 
-h1, h2, h3 {
-    margin-bottom: 0px;
+nav.main-nav a {
+  color: #1d1d1f;
+  text-decoration: none;
+  font-size: 0.9rem;
 }
 
-h2{
-    font-size: 35px;
-    text-align: center;
-    color: #000;
+nav.main-nav a:hover,
+nav.main-nav a.active {
+  color: #0071e3;
 }
-.container {
-    width: 80%;
-    margin: auto;
-    padding: 20px;
+
+.hero {
+  text-align: center;
+  padding: 15vh 1rem 10vh;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.25rem;
+  color: #555;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 100px 1rem 60px;
+}
+
+section {
+  margin-bottom: 80px;
+}
+
+h2 {
+  font-size: 2rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  text-align: center;
 }
 
 .project {
-    margin-bottom: 40px;
-}
- nav ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-}
-
-.container #skills ul{
-    list-style-type: none;
-}
-
-.container #skills{
-    padding: 0px;
-
-}
-nav{
-    background-color: #000;
-    font-weight: bold;
-    font-size: 21px;
-    position: fixed;
-    top: 0; /* La barre de navigation reste en haut */
-    width: 100%; /* La barre de navigation occupe toute la largeur */
-}
-nav ul li a {
-    text-decoration: none;
-    color: #fff;
-    transition: color 0.3s, transform 0.3s;
-}
-nav ul li a:hover {
-    color: #ccc;
-    transform: translateY(-2px);
+  margin-bottom: 40px;
 }
 
 .project h4 {
-    color: #000;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
-.project p {
-    margin-bottom: 10px;
+.project a {
+  text-decoration: none;
+  color: #0071e3;
 }
 
-nav ul li {
-    margin-bottom: 5px;
-    margin-right:100px ;
+.project a:hover {
+  text-decoration: underline;
+}
+
+ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul li {
+  margin-bottom: 0.5rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+form .row {
+  display: flex;
+  gap: 1rem;
+}
+
+.field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 150px;
+}
+
+button {
+  align-self: flex-start;
+  background-color: #1d1d1f;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #000;
 }
 
 footer {
-    background-color: #000;
-    color: #fff;
-    padding: 20px 0;
+  border-top: 1px solid #eaeaea;
+  text-align: center;
+  padding: 2rem;
 }
 
 .social-icons img {
-    width: 50px;
-    height: 50px;
-    margin: 0 10px;
-
+  width: 24px;
+  height: 24px;
+  margin: 0 10px;
 }
 
-
-
-header img {
-    width : 10vw ;
-    height: 10vw ;
-    border-radius: 50%;
-}
-footer p {
-    font-weight: bold;
-    margin-left: 10px;
-    font-size: 30px;
-}
-
-footer .container{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-footer a{
-    color: #fff;
-    text-decoration: none;
-}
-
-form{
-    background-color: #fff;
-    padding: 30px;
-    border-radius: 20px;
-    width: 80%;
-    margin: auto;
-}
-
-form h1{
-    font-size: 30px;
-    text-align: center;
-}
-
-form .separation{
-    width: 100px;
-    height: 2px;
-    background-color: #000;
-    margin: auto;
-}
-
-form .corps-formulaire{
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: 30px;
-    justify-content: center;
-    display: flex;
-    align-items: center;
-}
-form .corps-formulaire .boite{
-    position: relative;
-    margin-top: 20px;
-    display: flex;
+@media (max-width: 600px) {
+  form .row {
     flex-direction: column;
-}
-
-form .corps-formulaire .gauche .boite input{
-    margin-top: 5px;
-    padding:10px 5px 10px 30px ;
-    border:1px solid #c9c9c9;
-    outline-color: #000;
-    border-radius: 10px;
-}
-
-form .corps-formulaire .gauche .boite i{
-    position: absolute;
-    left: 0;
-    top: 25px;
-    padding: 15px 8px;
-    color:#000;
-}
-
-form .corps-formulaire .droite{
-    margin-left: 40px;
-}
-
-form .corps-formulaire .droite .boite{
-    height: 100%;
-}
-
-form .corps-formulaire .droite .boite textarea{
-    margin-top:5px ;
-    padding: 10px;
-    background-color: #f5f5f5;
-    border: 2px solid #000;
-    outline: none;
-    border-radius:10px ;
-    resize: none;
-    height: 200px;
-}
-form .pied-formulaire{
-    justify-content: center;
-    display: flex;
-    align-items: center;
-}
-textarea{
-    width: 100%;
-}
-form .pied-formulaire button{
-    margin-top: 10px;
-    background-color: #000;
-    color: #ffffff;
-    font-size: 15px;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 10px;
-    outline: none;
-    cursor: pointer;
-    transition: transform 0.5s;
-}
-
-form .pied-formulaire button:hover{
-    transform: scale(1.05);
-
-}
-
-form h1{
-    color: #000;
-}
-#overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color:#000; /* Fond semi-transparent */
-    z-index: 999; /* Assure que la superposition soit au-dessus de tout le reste */
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: top 1s ease-in-out; /* Animation de transition */
-}
-
-#overlay-content {
-    text-align: center;
-}
-#overlay-content h2{
-    color: #fff;
-    font-size: 50px;
-}
-#overlay.hidden {
-    top: -100%; /* Déplace la superposition hors de l'écran */
-}
-
-@media screen and (max-width:526px){
-    form .corps-formulaire .droite{
-        margin-left: 0px;
-    }
-}
-@media screen and (max-width: 880px){
-    header img {
-        width : 120px ;
-        height: 120px ;
-        border-radius: 50%;
-        border: 4px solid #000;
-    }
-}
-
-.project a{
-    text-decoration: none;
-    font-weight: bold;
-    color: #000;
-    border-bottom: 1px solid transparent;
-    transition: border-color 0.3s;
-}
-.project a:hover{
-    border-color: #000;
-}
-
-.fade-in {
-    opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-}
-
-.fade-in.visible {
-    opacity: 1;
-    transform: translateY(0);
+  }
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,18 +1,8 @@
-// Pour cacher la page du dessus
-setTimeout(function() {
-    var overlay = document.getElementById('overlay');
-    overlay.classList.add('hidden');
-}, 1000); // 1000 millisecondes = 1 secondes
-
-// Animation d'apparition des sections
-const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
-            observer.unobserve(entry.target);
-        }
-    });
+document.addEventListener('DOMContentLoaded', () => {
+  const current = window.location.pathname.split('/').pop() || 'index.html';
+  document.querySelectorAll('.main-nav a').forEach(link => {
+    if (link.getAttribute('href') === current) {
+      link.classList.add('active');
+    }
+  });
 });
-
-document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
-

--- a/skills.html
+++ b/skills.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Melchissedeck AFOUDAH</title>
+  <title>Compétences - Melchissedeck AFOUDAH</title>
   <link rel="stylesheet" href="public/css/style.css" />
 </head>
 <body>
@@ -16,10 +16,19 @@
     <a href="contact.html">Contact</a>
     <a href="CV-AFOUDAH Melchissedeck-data analyst.pdf" target="_blank">CV</a>
   </nav>
-  <header class="hero">
-    <h1>Melchissedeck AFOUDAH</h1>
-    <p>Étudiant en Data &amp; Intelligence Artificielle</p>
-  </header>
+  <main>
+    <section>
+      <h2>Compétences Techniques</h2>
+      <ul>
+        <li><strong>Collecte de données</strong> : MySQL, Python, R, API</li>
+        <li><strong>Traitement de données</strong> : Python, Numpy, Pandas, Scikit Learn, modèle additif de régression linéaire</li>
+        <li><strong>Visualisation de données</strong> : Matplotlib, PowerBI</li>
+        <li><strong>Programmation</strong> : Python, R</li>
+        <li><strong>Déploiement et gestion de projets</strong> : GitHub, Trello</li>
+        <li><strong>Langages Web</strong> : HTML, CSS, PHP, JavaScript, ReactJS</li>
+      </ul>
+    </section>
+  </main>
   <footer>
     <div class="social-icons">
       <a href="https://github.com/Melchissedeck" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub"></a>


### PR DESCRIPTION
## Summary
- Modernisation du design avec une esthétique minimaliste inspirée du site d'Apple
- Navigation réorganisée vers des pages indépendantes (À propos, Projets, Compétences, Éducation, Contact)
- Mise en évidence de l'onglet actif dans la barre de navigation

## Testing
- `npm test` *(échoue : aucun fichier package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73310fe1c83248cc17e5864f2b46f